### PR TITLE
fix(memento): prevent crash by skipping archive after JSON parse error

### DIFF
--- a/src/url_revive/archive_reader.py
+++ b/src/url_revive/archive_reader.py
@@ -56,6 +56,7 @@ def fetch_memento_snapshots(url, limit, match_codes):
         except Exception as e:  
             logging.error(f'Failed to parse response from archive, error - {e}')
             yield []
+            continue
         snapshots = []
         for entry in json_data:
             timestamp = entry['timestamp']


### PR DESCRIPTION
### Summary

This PR ensures that the `fetch_memento_snapshots` function properly skips over a failing archive when it encounters an exception during JSON parsing. Previously, even after `yield []`, the function would continue executing and attempt to loop over an invalid `json_data`, leading to runtime errors.

### Changes

- Added `continue` after `yield []` in the exception handler to skip to the next archive cleanly.
- Retains error logging to aid debugging.

### Before

When `format_data_to_json` raised an exception:
- The function logged the error.
- Yielded an empty list.
- Then **continued execution**, causing `TypeError` or similar when accessing `json_data`.

### After

Now:
- The function logs the error.
- Yields an empty list.
- **Skips the remaining logic** for the current archive by using `continue`.

### Test Plan

- Run the function with a known-broken archive response.
- Confirm that execution continues gracefully to the next archive without crashing.

### Related

None.

### Notes

If needed, we can later differentiate between soft errors (skip with yield) and hard errors (raise) for more granular control.